### PR TITLE
Fixed DefaultErrorComponent PropTypes

### DIFF
--- a/src/components/DefaultErrorComponent.js
+++ b/src/components/DefaultErrorComponent.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 
 const propTypes = {
-  error: PropTypes.string,
+  error: PropTypes.object,
 };
 
 const DefaultErrorComponent = ({ error }) => {


### PR DESCRIPTION
The DefaultErrorComponent should expect an error object instead of a string.
