### PR TITLE
Fix subscription leak of composeWithRedux

### DIFF
--- a/src/composers/withReduxState.js
+++ b/src/composers/withReduxState.js
@@ -23,7 +23,7 @@ function composeReduxBase(fn, props, onData) {
   };
 
   processState();
-  Store.subscribe(processState);
+  return Store.subscribe(processState);
 }
 
 export default function composeWithRedux(fn, L1, E1, options = { displayName: 'WithRedux' }) {


### PR DESCRIPTION
The return value of Store.subscribe is the unsubscribe handle. We must return this unsubscribe handle, so that whenever props are changed, we make sure the previous subscription is stopped before we subscribe again .
